### PR TITLE
Fix undefined showing up in output of hexFormat

### DIFF
--- a/mongoid.js
+++ b/mongoid.js
@@ -109,7 +109,12 @@ MongoId.prototype.mongoid = MongoId.prototype.fetch;
 var _zeroPadding = ["", "0", "00", "000", "0000", "00000", "000000", "0000000"];
 function hexFormat(n, width) {
     var s = n.toString(16);
-    return _zeroPadding[width - s.length] + s;
+    var paddingNeeded = width - s.length;
+    if (paddingNeeded > 0) {
+        return _zeroPadding[width - s.length] + s;
+    } else {
+        return s.substr(0, width);
+    }
 }
 MongoId.prototype.hexFormat = hexFormat;
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "unique",
     "ids"
   ],
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
+    "qnit": "^0.18.0"
   }
 }


### PR DESCRIPTION
Fixes #5 

Note, on my machine there are still 2 failing tests:

```
AssertionError: false is 'truthy'
    at Object.id should include pid (/Users/joshuaohlman/dev/node-mongoid-js/test/test-mongoid.js:155:11)
    at /Users/joshuaohlman/dev/node-mongoid-js/node_modules/qnit/lib/qnit.js:397:32
    at /Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:109:13
    at _invokeCallback (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:49:20)
    at applyFunc (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:103:50)
    at _loop (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:62:13)
    at repeatUntil (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:72:5)
    at Object.applyVisitor (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:101:5)
    at runit (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/qnit/lib/qnit.js:369:15)
    at runTestFunction (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/qnit/lib/qnit.js:352:5)

 X MongoId_class - testShouldParseId (1.115ms)

AssertionError: 5700 == 91208
    at Object.testShouldParseId (/Users/joshuaohlman/dev/node-mongoid-js/test/test-mongoid.js:194:14)
    at /Users/joshuaohlman/dev/node-mongoid-js/node_modules/qnit/lib/qnit.js:397:32
    at /Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:109:13
    at _invokeCallback (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:49:20)
    at applyFunc (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:103:50)
    at _loop (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:62:13)
    at repeatUntil (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:72:5)
    at Object.applyVisitor (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/aflow/lib/qflow.js:101:5)
    at runit (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/qnit/lib/qnit.js:369:15)
    at runTestFunction (/Users/joshuaohlman/dev/node-mongoid-js/node_modules/qnit/lib/qnit.js:352:5)

```